### PR TITLE
fix: SqlBuilder\MySqlBuilder does not support comment of column

### DIFF
--- a/src/LazyRecord/SqlBuilder/MysqlBuilder.php
+++ b/src/LazyRecord/SqlBuilder/MysqlBuilder.php
@@ -35,6 +35,9 @@ class MysqlBuilder
             }
         }
 
+        if( $column->comment )
+            $sql .= ' comment ' . $this->driver->inflate($column->comment);
+
         if( $column->primary )
             $sql .= ' primary key';
 


### PR DESCRIPTION
範例：

<pre>
namespace YourApp\Model;

use LazyRecord\Schema\SchemaDeclare;

class UserSchema extends SchemaDeclare
{
    public function schema()
    {
        // ...
        $this->column('name')
            ->varchar(10)
            ->notNull()
            ->comment('姓名');
    }
}
</pre>


修正前產生的 SQL ：

<pre>
name varchar(10) NOT NULL,
</pre>


修正後產生的 SQL ：

<pre>
name varchar(10) NOT NULL COMMENT '姓名'
</pre>

