### PR TITLE
Add support for mysql enum type

### DIFF
--- a/src/LazyRecord/Schema/SchemaDeclare/Column.php
+++ b/src/LazyRecord/Schema/SchemaDeclare/Column.php
@@ -60,6 +60,7 @@ class Column
             'notNull'       => self::ATTR_FLAG,
             'required'      => self::ATTR_FLAG,
             'typeConstraint' => self::ATTR_FLAG,
+            'enum'          => self::ATTR_ARRAY,
 
             /* column label */
             'label' => self::ATTR_ANY,
@@ -261,6 +262,13 @@ class Column
         return $this;
     }
 
+    public function enum()
+    {
+        $this->attributes['type'] = 'enum';
+        $this->attributes['isa'] = 'enum';
+        $this->attributes['enum'] = func_get_args();
+        return $this;
+    }
 
     /**
      * serial type

--- a/src/LazyRecord/SqlBuilder/MysqlBuilder.php
+++ b/src/LazyRecord/SqlBuilder/MysqlBuilder.php
@@ -18,6 +18,14 @@ class MysqlBuilder
         $sql = $this->driver->getQuoteColumn( $name );
         $sql .= ' ' . $type;
 
+        if ( $isa === 'enum' && !empty($column->enum) ) {
+            $enum = array();
+            foreach ($column->enum as $val) {
+                $enum[] = $this->driver->inflate($val);
+            }
+            $sql .= '(' . implode(', ', $enum) . ')';
+        }
+
         if( $column->required || $column->notNull )
             $sql .= ' NOT NULL';
         elseif( $column->null )


### PR DESCRIPTION
新增了 MySQL Enum 型態。

範例:

<pre>
namespace Annualsale\Model;

use LazyRecord\Schema\SchemaDeclare;

class UserSchema extends SchemaDeclare
{
    public function schema()
    {
        // ...
        $this->column('status')
            ->enum('y', 'n')
            ->default('y');
    }
}
</pre>


產生的 SQL:

<pre>
status enum('y', 'n') default 'y'
</pre>
